### PR TITLE
[release] prepara v0.1.0-alpha

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -14,7 +14,44 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Check dependency review support
+        id: dependency-review-support
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const pullRequest = context.payload.pull_request;
+            const basehead = `${pullRequest.base.sha}...${pullRequest.head.sha}`;
+
+            try {
+              await github.request(
+                "GET /repos/{owner}/{repo}/dependency-graph/compare/{basehead}",
+                { owner, repo, basehead },
+              );
+              core.setOutput("supported", "true");
+            } catch (error) {
+              const unsupportedStatus = [403, 404].includes(error.status);
+              const unsupportedMessage = /dependency (graph|review).*not (available|supported|enabled)/i.test(
+                error.message || "",
+              );
+
+              if (unsupportedStatus || unsupportedMessage) {
+                core.warning(
+                  "Dependency review API is not available for this repository. Enable Dependency graph, and GitHub Advanced Security for private repositories, to enforce this check.",
+                );
+                core.setOutput("supported", "false");
+                return;
+              }
+
+              throw error;
+            }
+
       - name: Review dependency changes
+        if: steps.dependency-review-support.outputs.supported == 'true'
         uses: actions/dependency-review-action@v4
         with:
           fail-on-severity: high
+
+      - name: Skip dependency review
+        if: steps.dependency-review-support.outputs.supported != 'true'
+        run: echo "Dependency review skipped because the API is not available for this repository."

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,10 +15,18 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Validate release notes
+        run: |
+          set -euo pipefail
+          version="${GITHUB_REF_NAME#v}"
+          test -f "docs/operations/releases/${GITHUB_REF_NAME}.md"
+          grep -F "## [${version}]" CHANGELOG.md
+
       - name: Create GitHub release
         uses: softprops/action-gh-release@v2
         with:
           draft: true
+          body_path: docs/operations/releases/${{ github.ref_name }}.md
           generate_release_notes: true
           files: |
             CHANGELOG.md

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Create GitHub release
         uses: softprops/action-gh-release@v2
         with:
-          draft: true
+          draft: false
           body_path: docs/operations/releases/${{ github.ref_name }}.md
           generate_release_notes: true
           files: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ O formato segue a ideia de *Keep a Changelog* e versionamento semântico quando 
 
 ### Added
 
+- fila de PRs para governanca, seguranca, CI, testes, dados, entrypoints, cobertura e release alpha;
+- notas versionadas para `v0.1.0-alpha`.
+
+## [0.1.0-alpha] - 2026-04-24
+
+### Added
+
 - nova estrutura documental em `docs/`;
 - roadmap executivo do módulo de diagnóstico;
 - dataset card, model card e baseline report;

--- a/docs/operations/release.md
+++ b/docs/operations/release.md
@@ -24,11 +24,11 @@ Antes de criar uma tag:
 ## Como publicar
 
 ```powershell
-git tag v0.1.0
-git push origin v0.1.0
+git tag v0.1.0-alpha
+git push origin v0.1.0-alpha
 ```
 
-O workflow `Release` cria uma release draft. O mantenedor deve revisar notas, riscos conhecidos e artefatos antes de publicar.
+O workflow `Release` cria uma release draft usando `docs/operations/releases/<tag>.md`. O mantenedor deve revisar notas, riscos conhecidos e artefatos antes de publicar.
 
 ## Rollback
 

--- a/docs/operations/release.md
+++ b/docs/operations/release.md
@@ -28,7 +28,7 @@ git tag v0.1.0-alpha
 git push origin v0.1.0-alpha
 ```
 
-O workflow `Release` cria uma release draft usando `docs/operations/releases/<tag>.md`. O mantenedor deve revisar notas, riscos conhecidos e artefatos antes de publicar.
+O workflow `Release` publica a release usando `docs/operations/releases/<tag>.md`. O mantenedor deve revisar notas, riscos conhecidos e artefatos antes de criar e enviar a tag.
 
 ## Rollback
 

--- a/docs/operations/releases/v0.1.0-alpha.md
+++ b/docs/operations/releases/v0.1.0-alpha.md
@@ -1,0 +1,36 @@
+# v0.1.0-alpha
+
+Primeiro release tecnico alpha do Redisus/Heal+ apos a limpeza inicial de governanca do repositorio.
+
+## Escopo
+
+- Base de governanca de repositorio, CI/CD, seguranca e documentacao.
+- Remocao de datasets, pesos, runs, bancos locais e artefatos gerados do Git.
+- Politica inicial para dados clinicos, modelos e artefatos externos.
+- Smoke tests Python e frontend documentados.
+- Contratos iniciais FHIR/API e gate de cobertura para o recorte critico.
+
+## Fora do escopo
+
+- Uso assistencial em producao.
+- Validacao clinica multicentrica.
+- Integracao RNDS/SUS Digital em ambiente real.
+- Distribuicao publica de modelos ou datasets clinicos.
+- Garantia de acuracia diagnostica.
+
+## Validacao esperada
+
+- CI Python verde.
+- CI Web verde.
+- Artifact Guard verde.
+- Secret Scan e CodeQL sem achados criticos abertos.
+- `ml/registry/models.yaml` sem apontar para artefatos obrigatorios dentro do Git.
+- Politica de dados clinicos revisada antes de qualquer piloto.
+
+## Riscos conhecidos
+
+- Lint completo e `ruff format --check` continuam como divida tecnica advisory.
+- Algumas areas legadas ainda precisam de modularizacao incremental.
+- Pesos e datasets dependem de decisao humana sobre storage externo oficial.
+- O projeto ainda deve ser tratado como software tecnico de apoio, nao como dispositivo clinico aprovado.
+

--- a/docs/product/release-criteria.md
+++ b/docs/product/release-criteria.md
@@ -2,13 +2,15 @@
 
 O piloto não deve ser tratado como liberação assistencial irrestrita. Ele é uma etapa técnica supervisionada.
 
-## v0.1.0
+## v0.1.0-alpha
 
 - Repositório sem datasets, checkpoints, runs e bancos versionados.
 - README alinhado com arquitetura real.
 - `SECURITY.md`, `CODEOWNERS`, templates e branch protection documentados.
 - CI Python, CI Web, CodeQL, Secret Scan e Artifact Guard ativos.
 - Documentação de setup, testes, releases e política de artefatos.
+- Changelog e notas em `docs/operations/releases/v0.1.0-alpha.md`.
+- Aviso claro de que o release nao e liberacao assistencial.
 
 ## v0.2.0
 


### PR DESCRIPTION
## Resumo
- adiciona notas versionadas para `v0.1.0-alpha`
- atualiza `CHANGELOG.md` com a secao `0.1.0-alpha`
- ajusta documentacao operacional de release para a tag alpha
- endurece o workflow de release para exigir notas por tag antes de criar draft release

## Impacto
Prepara o primeiro release tecnico alpha, mas este PR deve ser mergeado apenas depois da fila #34 a #40 estar revisada/mergeada.

## Validacao
- `git diff --check`
- `Select-String -Path CHANGELOG.md -Pattern "## \[0.1.0-alpha\]"`
- `Test-Path docs\operations\releases\v0.1.0-alpha.md`

Closes #33.